### PR TITLE
Replaced __constant with __global to make stockham kernels compatible with nVidia hardware

### DIFF
--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -2502,7 +2502,7 @@ namespace StockhamGenerator
 				str += "(";
 
 				// TODO : address this kludge
-				str += "__constant cb_t *cb __attribute__((max_constant_size(32))), ";
+				str += "__global cb_t *cb __attribute__((max_constant_size(32))), ";
 
 				// Function attributes
 				if(params.fft_placeness == CLFFT_INPLACE)


### PR DESCRIPTION
Fix is untested for performance impacts on AMD and Intel plattforms. Furthermore, I am not sure if **attribute**((max_constant_size(32))) still makes sense if __global keyword is used, because I do not find any documentation on this attribute.
