### PR TITLE
Fix OpenCL warnings with Intel OpenCL Runtime 16.1.2

### DIFF
--- a/src/library/generator.copy.cpp
+++ b/src/library/generator.copy.cpp
@@ -258,12 +258,12 @@ namespace CopyGenerator
 				// input
 				if(inIlvd)
 				{
-					str += "__global "; str += r2Type; str += " *lwbIn;\n\t";
+					str += "__global const "; str += r2Type; str += " *lwbIn;\n\t";
 				}
 				else
 				{
-					str += "__global "; str += rType; str += " *lwbInRe;\n\t";
-					str += "__global "; str += rType; str += " *lwbInIm;\n\t";
+					str += "__global const "; str += rType; str += " *lwbInRe;\n\t";
+					str += "__global const "; str += rType; str += " *lwbInIm;\n\t";
 				}
 			}
 

--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -3469,19 +3469,7 @@ namespace StockhamGenerator
 				else	str += "fft_back";
 				str += "(";
 
-        // TODO : address this kludge
-        size_t SizeParam_ret = 0;
-        clGetDeviceInfo(Dev_ID, CL_DEVICE_VENDOR, 0, NULL, &SizeParam_ret);
-        char* nameVendor = new char[SizeParam_ret];
-        clGetDeviceInfo(Dev_ID, CL_DEVICE_VENDOR, SizeParam_ret, nameVendor, NULL);
-
-        //nv compiler doesn't support __constant kernel argument
-        if (strncmp(nameVendor, "NVIDIA",6)!=0)
-          str += "__constant cb_t *cb __attribute__((max_constant_size(32))), ";
-        else
-          str += "__global cb_t *cb, ";
-
-        delete [] nameVendor;
+        str += "__global cb_t *cb, ";
 
 		//If plan has pre/post callback
 		callbackstr.clear();

--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -2098,20 +2098,20 @@ namespace StockhamGenerator
 				{
 					if(inInterleaved)
 					{
-										passStr += "__global "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
-						if(!rcSimple) {	passStr += "__global "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
+										passStr += "__global const "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						if(!rcSimple) {	passStr += "__global const "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
 					}
 					else if(inReal)
 					{
-										passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
-						if(!rcSimple) {	passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
+										passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						if(!rcSimple) {	passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
 					}
 					else
 					{
-										passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
-						if(!rcSimple) {	passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
-										passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm;  passStr += ", ";
-						if(!rcSimple) {	passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm2; passStr += ", "; }
+										passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						if(!rcSimple) {	passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe2; passStr += ", "; }
+										passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm;  passStr += ", ";
+						if(!rcSimple) {	passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm2; passStr += ", "; }
 					}
 				}
 				else
@@ -2152,24 +2152,24 @@ namespace StockhamGenerator
 				{
 					if(inInterleaved)
 					{
-						passStr += "__global "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						passStr += "__global const "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
 					}
 					else
 					{
-						passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
-						passStr += "__global "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm;  passStr += ", ";
+						passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						passStr += "__global const "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm;  passStr += ", ";
 					}
 				}
 				else
 				{
 					if(inInterleaved)
 					{
-						passStr += "__local "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
+						passStr += "__local const "; passStr += regB2Type; passStr += " *"; passStr += bufferInRe;  passStr += ", ";
 					}
 					else
 					{
-						passStr += "__local "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe; passStr += ", ";
-						passStr += "__local "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm; passStr += ", ";
+						passStr += "__local const "; passStr += regB1Type; passStr += " *"; passStr += bufferInRe; passStr += ", ";
+						passStr += "__local const "; passStr += regB1Type; passStr += " *"; passStr += bufferInIm; passStr += ", ";
 					}
 				}
 
@@ -3553,11 +3553,11 @@ namespace StockhamGenerator
 					{
 						if(inInterleaved)
 						{
-							str += "__global "; str += r2Type; str += " * restrict gbIn, ";
+							str += "__global const "; str += r2Type; str += " * restrict gbIn, ";
 						}
 						else if(inReal)
 						{
-							str += "__global "; str += rType; str += " * restrict gbIn, ";
+							str += "__global const "; str += rType; str += " * restrict gbIn, ";
 						}
 						else
 						{
@@ -3664,22 +3664,22 @@ namespace StockhamGenerator
 					{ 
 						if(inInterleaved)
 						{
-							if(!rcSimple)	{	str += "__global "; str += r2Type; str += " *lwbIn2;\n\t"; }
-												str += "__global "; str += r2Type; str += " *lwbIn;\n\t";  
+							if(!rcSimple)	{	str += "__global const "; str += r2Type; str += " *lwbIn2;\n\t"; }
+												str += "__global const "; str += r2Type; str += " *lwbIn;\n\t";
 						}
 						else if(inReal)
 						{
-							if(!rcSimple)	{	str += "__global "; str += rType; str += " *lwbIn2;\n\t"; }
-												str += "__global "; str += rType; str += " *lwbIn;\n\t";
+							if(!rcSimple)	{	str += "__global const "; str += rType; str += " *lwbIn2;\n\t"; }
+												str += "__global const "; str += rType; str += " *lwbIn;\n\t";
 
 						}
 						else
 						{
-							if(!rcSimple)	{	str += "__global "; str += rType; str += " *lwbInRe2;\n\t"; }
-							if(!rcSimple)	{	str += "__global "; str += rType; str += " *lwbInIm2;\n\t"; }
+							if(!rcSimple)	{	str += "__global const "; str += rType; str += " *lwbInRe2;\n\t"; }
+							if(!rcSimple)	{	str += "__global const "; str += rType; str += " *lwbInIm2;\n\t"; }
 							  
-												str += "__global "; str += rType; str += " *lwbInRe;\n\t"; 
-												str += "__global "; str += rType; str += " *lwbInIm;\n\t"; 
+												str += "__global const "; str += rType; str += " *lwbInRe;\n\t"; 
+												str += "__global const "; str += rType; str += " *lwbInIm;\n\t"; 
 							
 						}
 					}
@@ -3743,12 +3743,12 @@ namespace StockhamGenerator
 						{
 							if(inInterleaved)
 							{
-								str += "__global "; str += r2Type; str += " *lwbIn;\n\t";
+								str += "__global const "; str += r2Type; str += " *lwbIn;\n\t";
 							}
 							else
 							{
-								str += "__global "; str += rType; str += " *lwbInRe;\n\t";
-								str += "__global "; str += rType; str += " *lwbInIm;\n\t";
+								str += "__global const "; str += rType; str += " *lwbInRe;\n\t";
+								str += "__global const "; str += rType; str += " *lwbInIm;\n\t";
 							}
 						}
 

--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -820,7 +820,8 @@ namespace StockhamGenerator
 
 				passStr += "\n\t";
 				passStr += "__global "; passStr += RegBaseType<PR>(4);
-				passStr += " *buff4g = "; passStr += bufferRe; passStr += ";\n\t"; // Assuming 'outOffset' is 0, so not adding it here
+				passStr += " *buff4g = (__global "; passStr += RegBaseType<PR>(4); passStr += " *)";
+				passStr += bufferRe; passStr += ";\n\t"; // Assuming 'outOffset' is 0, so not adding it here
 
 				for(size_t r=0; r<radix; r++) // setting the radix loop outside to facilitate grouped writing
 				{

--- a/src/tests/test_constants.h
+++ b/src/tests/test_constants.h
@@ -24,7 +24,7 @@
 #include <stdexcept>
 
 //Pre-callback function strings
-#define PRE_MULVAL float2 mulval_pre(__global void* in, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL float2 mulval_pre(__global const void* in, uint offset, __global void* userdata)\n \
 				{ \n \
 				float scalar = *((__global float*)userdata + offset); \n \
 				float2 ret = *((__global float2*)in + offset) * scalar; \n \
@@ -36,7 +36,7 @@
 						float scalar1;  \
 						float scalar2;  \
 						} USER_DATA; \n \
-					float2 mulval_pre(__global void* in, uint offset, __global void* userdata)\n \
+					float2 mulval_pre(__global const void* in, uint offset, __global void* userdata)\n \
 					{ \n \
 					__global USER_DATA *data = ((__global USER_DATA *)userdata + offset); \n \
 					float scalar = data->scalar1 * data->scalar2; \n \
@@ -44,14 +44,14 @@
 					return ret; \n \
 					}
 
-#define PRE_MULVAL_DP double2 mulval_pre(__global void* in, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL_DP double2 mulval_pre(__global const void* in, uint offset, __global void* userdata)\n \
 				{ \n \
 				double scalar = *((__global double*)userdata + offset); \n \
 				double2 ret = *((__global double2*)in + offset) * scalar; \n \
 				return ret; \n \
 				}
 
-#define PRE_MULVAL_PLANAR float2 mulval_pre(__global void* inRe, __global void* inIm, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL_PLANAR float2 mulval_pre(__global const void* inRe, __global const void* inIm, uint offset, __global void* userdata)\n \
 				{ \n \
 				float scalar = *((__global float*)userdata + offset); \n \
 				float2 ret; \n \
@@ -60,7 +60,7 @@
 				return ret; \n \
 				}
 
-#define PRE_MULVAL_PLANAR_DP double2 mulval_pre(__global void* inRe, __global void* inIm, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL_PLANAR_DP double2 mulval_pre(__global const void* inRe, __global const void* inIm, uint offset, __global void* userdata)\n \
 				{ \n \
 				double scalar = *((__global double*)userdata + offset); \n \
 				double2 ret; \n \
@@ -69,14 +69,14 @@
 				return ret; \n \
 				}
 
-#define PRE_MULVAL_REAL float mulval_pre(__global void* in, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL_REAL float mulval_pre(__global const void* in, uint offset, __global void* userdata)\n \
 				{ \n \
 				float scalar = *((__global float*)userdata + offset); \n \
 				float ret = *((__global float*)in + offset) * scalar; \n \
 				return ret; \n \
 				}
 
-#define PRE_MULVAL_REAL_DP double mulval_pre(__global void* in, uint offset, __global void* userdata)\n \
+#define PRE_MULVAL_REAL_DP double mulval_pre(__global const void* in, uint offset, __global void* userdata)\n \
 				{ \n \
 				double scalar = *((__global double*)userdata + offset); \n \
 				double ret = *((__global double*)in + offset) * scalar; \n \
@@ -84,7 +84,7 @@
 				}
 
 //Precallback test for LDS - works when 1 WI works on one input element
-#define PRE_MULVAL_LDS float2 mulval_pre(__global void* in, uint offset, __global void* userdata, __local void* localmem)\n \
+#define PRE_MULVAL_LDS float2 mulval_pre(__global const void* in, uint offset, __global void* userdata, __local void* localmem)\n \
 				{ \n \
 				uint lid = get_local_id(0); \n \
 				__local float* lds = (__local float*)localmem + lid; \n \


### PR DESCRIPTION
This backports 2 commits from https://github.com/clMathLibraries/clFFT/commits/develop and adds missing const qualifiers to avoid OpenCL warnings with Intel OpenCL Runtime 16.1.2 on Linux x86_64.
@9prady9 @umar456