### PR TITLE
Remove use of deprecated unary_function 

### DIFF
--- a/src/statTimer/statisticalTimer.CPU.cpp
+++ b/src/statTimer/statisticalTimer.CPU.cpp
@@ -62,7 +62,7 @@ std::basic_string<TCHAR> commatize (T number)
 
 //	Functor object to help with accumulating values in vectors
 template< typename T >
-struct Accumulator
+struct Accumulator: public std::function<void(T)>
 {
 	T acc;
 

--- a/src/statTimer/statisticalTimer.CPU.cpp
+++ b/src/statTimer/statisticalTimer.CPU.cpp
@@ -62,7 +62,7 @@ std::basic_string<TCHAR> commatize (T number)
 
 //	Functor object to help with accumulating values in vectors
 template< typename T >
-struct Accumulator: public std::unary_function< T, void >
+struct Accumulator
 {
 	T acc;
 

--- a/src/statTimer/statisticalTimer.GPU.cpp
+++ b/src/statTimer/statisticalTimer.GPU.cpp
@@ -54,7 +54,7 @@ std::basic_string<TCHAR> commatize (T number)
 
 //	Functor object to help with accumulating values in vectors
 template< typename T >
-struct Accumulator: public std::unary_function< T, void >
+struct Accumulator
 {
 	T acc;
 

--- a/src/statTimer/statisticalTimer.GPU.cpp
+++ b/src/statTimer/statisticalTimer.GPU.cpp
@@ -54,7 +54,7 @@ std::basic_string<TCHAR> commatize (T number)
 
 //	Functor object to help with accumulating values in vectors
 template< typename T >
-struct Accumulator
+struct Accumulator: public std::function<void(T)>
 {
 	T acc;
 

--- a/src/statTimer/statisticalTimer.h
+++ b/src/statTimer/statisticalTimer.h
@@ -35,11 +35,11 @@
 //	Definition of a functor object that is passed by reference into the Print statement
 //	of the timing class.
 //	Functor object to help with accumulating values in vectors
-template<typename R >
-class flopsFunc
+template<typename A, typename R >
+class flopsFunc: public std::function<R(A)>
 {
 public:
-	virtual R operator( )( ) = 0;
+	virtual typename std::function<R(A)>::result_type operator( )( ) = 0;
 };
 
 /**

--- a/src/statTimer/statisticalTimer.h
+++ b/src/statTimer/statisticalTimer.h
@@ -35,11 +35,11 @@
 //	Definition of a functor object that is passed by reference into the Print statement
 //	of the timing class.
 //	Functor object to help with accumulating values in vectors
-template< typename A, typename R >
-class flopsFunc: public std::unary_function< A, R >
+template<typename R >
+class flopsFunc
 {
 public:
-	virtual typename std::unary_function<A, R>::result_type operator( )( ) = 0;
+	virtual R operator( )( ) = 0;
 };
 
 /**


### PR DESCRIPTION
Remove use of deprecated unary_function  which is causing build issues with Visual Studio 2022 / MSVC v144